### PR TITLE
Ensure level number always displays the correct level

### DIFF
--- a/core/src/main/java/io/github/fourlastor/game/ui/XpBar.java
+++ b/core/src/main/java/io/github/fourlastor/game/ui/XpBar.java
@@ -90,7 +90,11 @@ public class XpBar extends WidgetGroup {
                 Actions.scaleTo(amount, 1f, 0.15f, Interpolation.pow2),
                 Actions.run(() -> filledEnd.setVisible(visible)));
         if (!levelUp) {
-            action = setProgressAction;
+            action = Actions.sequence(setProgressAction, Actions.run(() -> {
+                levelLabel.setVariable("level", String.valueOf(level));
+                levelLabel.restart();
+                levelLabel.skipToTheEnd();
+            }));
         } else {
             action = Actions.sequence(
                     Actions.scaleTo(1, 1f, 0.15f, Interpolation.pow2),


### PR DESCRIPTION
https://user-images.githubusercontent.com/1263058/227934770-3cd187da-a8b8-48ab-9591-54000707483a.mp4

The issue was that the level was only set when `levelUp == true`, which was part of an action that could be cancelled by a subsequent action (likely with `levelUp == false` as the player just leveled up).